### PR TITLE
Allow compilation with GOARCH set to 386

### DIFF
--- a/int_buffer.go
+++ b/int_buffer.go
@@ -34,13 +34,13 @@ func (buf *IntBuffer) AsFloatBuffer() *FloatBuffer {
 func (buf *IntBuffer) AsFloat32Buffer() *Float32Buffer {
 	newB := &Float32Buffer{}
 	newB.Data = make([]float32, len(buf.Data))
-	max := 0
+	max := int64(0)
 	bitDepth := buf.SourceBitDepth
 	// try to guess the bit depths without knowing the source
 	if bitDepth == 0 {
 		for _, s := range buf.Data {
-			if s > max {
-				max = s
+			if int64(s) > max {
+				max = int64(s)
 			}
 		}
 		bitDepth = 8


### PR DESCRIPTION
prior to this change:

```
$ GOARCH=386 go test  github.com/tmpvar/go-audio-audio
# github.com/tmpvar/go-audio-audio
./int_buffer.go:59:10: constant 4294967295 overflows int
FAIL	github.com/tmpvar/go-audio-audio [build failed]
```

and after:

```
$ GOARCH=386 go test  github.com/tmpvar/go-audio-audio
ok  	github.com/tmpvar/go-audio-audio	0.004s
```