### PR TITLE
Basic reflect types for package consumers to use

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -2,6 +2,7 @@ package audio
 
 import (
 	"errors"
+	"reflect"
 )
 
 var (
@@ -32,4 +33,7 @@ type Buffer interface {
 	// Clone creates a clean clone that can be modified without
 	// changing the source buffer.
 	Clone() Buffer
+	// Type returns a reflect value for determining the type
+	// for on the fly conversions
+	Type() reflect.Kind
 }

--- a/float_buffer.go
+++ b/float_buffer.go
@@ -1,5 +1,7 @@
 package audio
 
+import "reflect"
+
 var _ Buffer = (*FloatBuffer)(nil)
 var _ Buffer = (*Float32Buffer)(nil)
 
@@ -72,6 +74,11 @@ func (buf *FloatBuffer) NumFrames() int {
 	}
 
 	return len(buf.Data) / numChannels
+}
+
+// Type returns the type of this buffer
+func (buf *FloatBuffer) Type() reflect.Kind {
+	return reflect.Float64
 }
 
 // Float32Buffer is an audio buffer with its PCM data formatted as float32.
@@ -153,4 +160,9 @@ func (buf *Float32Buffer) NumFrames() int {
 	}
 
 	return len(buf.Data) / numChannels
+}
+
+// Type returns the type of this buffer
+func (buf *Float32Buffer) Type() reflect.Kind {
+	return reflect.Float32
 }

--- a/float_buffer_test.go
+++ b/float_buffer_test.go
@@ -97,9 +97,15 @@ func TestFloat32Buffer(t *testing.T) {
 			if !reflect.DeepEqual(fb64.Data, tt.f64) {
 				t.Errorf("Expected %+v got %+v", tt.f64, fb64.Data)
 			}
+			if fb64.Type() != reflect.Float64 {
+				t.Errorf("buffer was improperly typed: %v", fb64.Type())
+			}
 			integer := fb.AsIntBuffer()
 			if !reflect.DeepEqual(integer.Data, tt.integer) {
 				t.Errorf("Expected %+v got %+v", tt.integer, integer.Data)
+			}
+			if integer.Type() != reflect.Int {
+				t.Errorf("buffer was improperly typed: %v", integer.Type())
 			}
 		})
 	}

--- a/int_buffer.go
+++ b/int_buffer.go
@@ -1,6 +1,9 @@
 package audio
 
-import "math"
+import (
+	"math"
+	"reflect"
+)
 
 var _ Buffer = (*IntBuffer)(nil)
 
@@ -103,4 +106,9 @@ func (buf *IntBuffer) Clone() Buffer {
 		SampleRate:  buf.Format.SampleRate,
 	}
 	return newB
+}
+
+// Type returns the type of this buffer
+func (buf *IntBuffer) Type() reflect.Kind {
+	return reflect.Int
 }

--- a/int_buffer_test.go
+++ b/int_buffer_test.go
@@ -37,14 +37,20 @@ func TestIntBuffer_AsFloat32Buffer(t *testing.T) {
 					t.Errorf("%d was converted out of range to %f", intData[i], f)
 				}
 			}
-
 			if got.Type() != reflect.Float32 {
 				t.Errorf("buffer was improperly typed: %v", got.Type())
 			}
+
+			gotb := got.Clone()
+			got64 := gotb.AsFloatBuffer()
+			for i, f := range got64.Data {
+				if f < -1.0 || f > 1.0 {
+					t.Errorf("%d was converted out of range to %f", intData[i], f)
+				}
+			}
+			if got64.Type() != reflect.Float64 {
+				t.Errorf("buffer was improperly typed: %v", got64.Type())
+			}
 		})
 	}
-}
-
-func TestBufferType(t *testing.T) {
-
 }

--- a/int_buffer_test.go
+++ b/int_buffer_test.go
@@ -1,6 +1,7 @@
 package audio
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -36,6 +37,14 @@ func TestIntBuffer_AsFloat32Buffer(t *testing.T) {
 					t.Errorf("%d was converted out of range to %f", intData[i], f)
 				}
 			}
+
+			if got.Type() != reflect.Float32 {
+				t.Errorf("buffer was improperly typed: %v", got.Type())
+			}
 		})
 	}
+}
+
+func TestBufferType(t *testing.T) {
+
 }

--- a/pcm_buffer.go
+++ b/pcm_buffer.go
@@ -1,6 +1,9 @@
 package audio
 
-import "math"
+import (
+	"math"
+	"reflect"
+)
 
 // PCMDataFormat is an enum type to indicate the underlying data format used.
 type PCMDataFormat uint8
@@ -458,4 +461,27 @@ func (b *PCMBuffer) calculateIntBitDepth() uint8 {
 	}
 
 	return bitDepth
+}
+
+// Type returns the type of this buffer
+func (b *PCMBuffer) Type() reflect.Kind {
+	if b == nil {
+		return reflect.Invalid
+	}
+
+	switch b.DataType {
+	case DataTypeI8:
+		return reflect.Int8
+	case DataTypeI16:
+		return reflect.Int16
+	case DataTypeI32:
+		return reflect.Int32
+	case DataTypeF32:
+		return reflect.Float32
+	case DataTypeF64:
+		return reflect.Float64
+	default:
+		return reflect.Invalid
+	}
+
 }

--- a/pcm_buffer_test.go
+++ b/pcm_buffer_test.go
@@ -45,6 +45,15 @@ func TestPCMBuffer_AsFloatBuffer(t *testing.T) {
 			if !reflect.DeepEqual(pcmb.AsI32(), tt.i32) {
 				t.Errorf("Expected %+v got %+v", tt.i32, pcmb.AsI32())
 			}
+			if pcmb.Type() != reflect.Int8 {
+				t.Errorf("buffer was improperly typed: %v", pcmb.Type())
+			}
+			if pcmb32.Type() != reflect.Float32 {
+				t.Errorf("buffer was improperly typed: %v", pcmb32.Type())
+			}
+			if pcmb64.Type() != reflect.Float64 {
+				t.Errorf("buffer was improperly typed: %v", pcmb64.Type())
+			}
 		})
 	}
 

--- a/pcm_buffer_test.go
+++ b/pcm_buffer_test.go
@@ -1,0 +1,51 @@
+package audio
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPCMBuffer_AsFloatBuffer(t *testing.T) {
+	tests := []struct {
+		name     string
+		datatype PCMDataFormat
+		bd       uint8
+		i8       []int8
+		i16      []int16
+		i32      []int32
+		f32      []float32
+		f64      []float64
+	}{
+		{"int8 conversion", DataTypeI8, 1, []int8{1, 2, 3}, []int16{1, 2, 3}, []int32{1, 2, 3}, []float32{2, 4, 6}, []float64{2, 4, 6}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pcmb := PCMBuffer{
+				Format:         FormatMono22500,
+				I8:             tt.i8,
+				SourceBitDepth: tt.bd,
+				DataType:       tt.datatype,
+			}
+
+			// I'm unsure if the actual behavior is for int8 individual
+			// data to double the way it did
+			// 1,2,3  => 2,4,6
+			pcmb32 := pcmb.AsFloat32Buffer()
+			if !reflect.DeepEqual(pcmb32.Data, tt.f32) {
+				t.Errorf("Expected %+v got %+v", tt.f32, pcmb32.Data)
+			}
+			pcmb64 := pcmb.AsFloatBuffer()
+			if !reflect.DeepEqual(pcmb64.Data, tt.f64) {
+				t.Errorf("Expected %+v got %+v", tt.f64, pcmb64.Data)
+			}
+
+			if !reflect.DeepEqual(pcmb.AsI16(), tt.i16) {
+				t.Errorf("Expected %+v got %+v", tt.i8, pcmb.AsI16())
+			}
+			if !reflect.DeepEqual(pcmb.AsI32(), tt.i32) {
+				t.Errorf("Expected %+v got %+v", tt.i32, pcmb.AsI32())
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This feature derived from conversation in https://github.com/go-audio/wav/issues/20

I am using reflective types but performing no reflection, there should  be no performance difference or compatibility issues, outside of projects conforming to the interface.

The intention  for these changes would be for the Write() encoder function to be able to ask the type so it can utilize `AsIntBuffer` only when required - allowing Write() to accept the buf Interface instead of type  so it can accept any type  but then silently convert to int before passing it on. 

This is meant to be an early step to support any type in write without actually writing  any type.